### PR TITLE
Fix NullPointerException caused by asynchronous entityMap read

### DIFF
--- a/core/src/main/java/me/matsubara/realisticvillagers/npc/NPCPool.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/npc/NPCPool.java
@@ -40,7 +40,7 @@ public class NPCPool implements Listener {
 
     protected void tick() {
         Bukkit.getScheduler().runTaskTimer(plugin, () -> {
-            for (Player player : ImmutableList.copyOf(Bukkit.getOnlinePlayers())) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
                 for (NPC npc : npcMap.values()) {
                     Location npcLocation = npc.getLocation();
                     Location playerLocation = player.getLocation();

--- a/core/src/main/java/me/matsubara/realisticvillagers/npc/NPCPool.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/npc/NPCPool.java
@@ -39,7 +39,7 @@ public class NPCPool implements Listener {
     }
 
     protected void tick() {
-        Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
+        Bukkit.getScheduler().runTaskTimer(plugin, () -> {
             for (Player player : ImmutableList.copyOf(Bukkit.getOnlinePlayers())) {
                 for (NPC npc : npcMap.values()) {
                     Location npcLocation = npc.getLocation();


### PR DESCRIPTION
After my in-depth investigation, I have come to a preliminary conclusion.

[`NMSConverter#isBeingTracked`](https://github.com/aematsubara/RealisticVillagers/blob/50b697cfb640c44da4fa2891fce0ee0b8158f331/1_20_R1/src/main/java/me/matsubara/realisticvillagers/nms/v1_20_r1/NMSConverter.java#L373) will use  `entityMap` for iterate over all elements to check if a NPC is being tracked.

But, `NMSConverter#isBeingTracked` is invoked from a [`Bukkit Asynchronous Scheduler` in NPCPool#tick](https://github.com/aematsubara/RealisticVillagers/blob/50b697cfb640c44da4fa2891fce0ee0b8158f331/core/src/main/java/me/matsubara/realisticvillagers/npc/NPCPool.java#L42) and `entityMap` not a thread-safe collection, Due to the internal implementation of FastUtils, this error can be seen as  FastUtil's ConcurrentModificationException.

This issue cannot be reproduced on the local test server because the error only occurs when the `entityMap` is modified.

On a busy live server, the error is more likely to be triggered by a large number of players.

---

Ref:

[Error: java.lang.NullPointerException: Cannot invoke "it.unimi.dsi.fastutil.ints.IntArrayList.getInt(int)" - Forge Forums](https://forums.minecraftforge.net/topic/117065-error-javalangnullpointerexception-cannot-invoke-itunimidsifastutilintsintarraylistgetintint/)
https://github.com/theorbtwo/RoughlyEnoughResources/issues/15
https://github.com/PaperMC/Paper/issues/6758
https://github.com/PaperMC/Paper/issues/8813
[Minecraft Server randomly crashes | SpigotMC - High Performance Minecraft](https://www.spigotmc.org/threads/minecraft-server-randomly-crashes.597675/)