### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/core/src/main/java/me/matsubara/realisticvillagers/util/ItemStackUtils.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/util/ItemStackUtils.java
@@ -270,7 +270,7 @@ public final class ItemStackUtils {
 
         points += getSharpnessPoints(item);
 
-        // https://minecraft.fandom.com/wiki/Fire_Aspect - (level × 4) – 1.
+        // https://minecraft.wiki/w/Fire_Aspect - (level × 4) – 1.
         int fireAspectLevel = item.getEnchantmentLevel(Enchantment.FIRE_ASPECT);
         if (fireAspectLevel > 0) {
             points += (((double) fireAspectLevel * 4) - 1) * 10 / 100;
@@ -280,7 +280,7 @@ public final class ItemStackUtils {
     }
 
     private static double getSharpnessPoints(@NotNull ItemStack item) {
-        // https://minecraft.fandom.com/wiki/Sharpness - 0.5 * level + 0.5.
+        // https://minecraft.wiki/w/Sharpness - 0.5 * level + 0.5.
         int sharpnessLevel = item.getEnchantmentLevel(Enchantment.DAMAGE_ALL);
         return (sharpnessLevel > 0) ? 0.5d * sharpnessLevel + 0.5d : 0.0d;
     }
@@ -288,7 +288,7 @@ public final class ItemStackUtils {
     private static double getBowBasePoints(@NotNull ItemStack item) {
         double points = 0.0d;
 
-        // https://minecraft.fandom.com/wiki/Power - 25% * (level + 1).
+        // https://minecraft.wiki/w/Power - 25% * (level + 1).
         int powerLevel = item.getEnchantmentLevel(Enchantment.ARROW_DAMAGE);
         if (powerLevel > 0) {
             points += 0.25d * (powerLevel + 1);
@@ -300,7 +300,7 @@ public final class ItemStackUtils {
     private static double getTridentBasePoints(@NotNull ItemStack item) {
         double points = 0.0d;
 
-        // https://minecraft.fandom.com/wiki/Impaling - level × 2.5.
+        // https://minecraft.wiki/w/Impaling - level × 2.5.
         int impalingLevel = item.getEnchantmentLevel(Enchantment.IMPALING);
         if (impalingLevel > 0) {
             points += impalingLevel * 2.5d;

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -187,7 +187,7 @@ input-gui:
 # This only applies to villagers who have not yet spawned.
 # If the villager has no weapon in hand, he will flee from danger.
 # NOTE: Only monsters are supported at the moment (ENDER_DRAGON & WITHER included).
-# Monsters: https://minecraft.fandom.com/wiki/Mob#Hostile_mobs
+# Monsters: https://minecraft.wiki/w/Mob#Hostile_mobs
 default-target-entities:
   - DROWNED
   - EVOKER
@@ -914,7 +914,7 @@ bad-gift-reputation: 5
 # The list of accepted items for each gift level.
 # Minimum reputation value: 2; use 1 or less to disable.
 #
-# For a list of tags, visit https://minecraft.fandom.com/wiki/Tag#List_of_tags
+# For a list of tags, visit https://minecraft.wiki/w/Tag#List_of_tags
 # Tag format: ${tag-name}
 # Tag example: $LEATHER_ARMOR_PIECES
 #
@@ -1284,7 +1284,7 @@ speed-modifier:
 baby-look-height-offset: 0.0
 
 # Here you can modify the schedule of the villagers and their respective activities whether they're babies or adults.
-# For more information, take a look at: https://minecraft.fandom.com/wiki/Villager#Schedules
+# For more information, take a look at: https://minecraft.wiki/w/Villager#Schedules
 #
 # NOTE: Don't touch this if you don't know what you're doing!
 # Available activities: IDLE, PLAY, WORK, MEET, REST.


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.