### PR TITLE
Compatibility with Marriage Master plugin using the api. 👍🏻 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+# This is a basic workflow to help you get started with Actions 
+ name: RealisticVillagers Builder 
+ # Controls when the action will run. Triggers the workflow on push or pull request 
+ # events but only for the master branch 
+ on: 
+   workflow_dispatch: 
+     inputs: 
+       logLevel: 
+         description: 'Log level' 
+         required: true 
+         default: 'warning' 
+       tags: 
+         description: 'Test scenario tags' 
+   push: 
+     branches: [ "master" ] 
+   pull_request: 
+     branches: [ "master" ] 
+  
+ jobs: 
+   build:
+     permissions: write-all 
+     runs-on: ubuntu-latest 
+     steps: 
+     - uses: actions/checkout@v3 
+     - name: Set up JDK 17 
+       uses: actions/setup-java@v3 
+       with: 
+         java-version: '17' 
+         distribution: 'temurin' 
+         server-id: phoenixdevt-releases 
+     - name: Set up JDK 21 
+       uses: actions/setup-java@v3 
+       with: 
+         java-version: '21' 
+         distribution: 'temurin' 
+         server-id: phoenixdevt-releases 
+     - name: Install depends 
+       run: mvn install
+     - name: Build with Maven 
+       run: mvn -B package --file pom.xml
+     - run: mkdir staging && cp target/*.jar staging 
+     - name: Set Release version env variable 
+       run: | 
+         echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV 
+     - name: "Build & test" 
+       run: | 
+         echo "done!" 
+     - uses: "marvinpinto/action-automatic-releases@latest" 
+       with: 
+         repo_token: "${{ secrets.GITHUB_TOKEN }}" 
+         automatic_release_tag: "${{ env.RELEASE_VERSION }}" 
+         prerelease: false 
+         title: "Release ${{ env.RELEASE_VERSION }}" 
+         files: | 
+           staging/*.jar

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,6 +149,10 @@
             <id>viaversion-repo</id>
             <url>https://repo.viaversion.com</url>
         </repository>
+        <repository>
+            <id>pcgf-repo</id>
+            <url>https://repo.pcgamingfreaks.at/repository/maven-everything</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -225,6 +229,13 @@
             <groupId>com.github.retrooper</groupId>
             <artifactId>packetevents-spigot</artifactId>
             <version>2.7.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Marriage Master API -->
+        <dependency>
+            <groupId>at.pcgamingfreaks</groupId>
+            <artifactId>MarriageMaster-API-Bukkit</artifactId>
+            <version>2.4</version><!-- Check api-version shield for newest version -->
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>at.pcgamingfreaks</groupId>
             <artifactId>MarriageMaster-API-Bukkit</artifactId>
-            <version>2.4</version><!-- Check api-version shield for newest version -->
+            <version>2.7.8</version><!-- Check api-version shield for newest version -->
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -807,18 +807,15 @@ public final class RealisticVillagers extends JavaPlugin {
         return getCompatibilityManager().marriedPlayer(player);
     }
     public boolean isMarried(@NotNull Player player) {
+        if (marriedPlayer(player)) return true;
         String partner = player.getPersistentDataContainer().get(marriedWith, PersistentDataType.STRING);
         if (partner == null) return false;
-
-        if (!marriedPlayer(player)) return false;
         
         IVillagerNPC partnerInfo = tracker.getOffline(UUID.fromString(partner));
         if (partnerInfo == null) {
             player.getPersistentDataContainer().remove(marriedWith);
             return false;
         }
-        System.out.println("esta casado");
-
         return true;
     }
 

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -98,6 +98,7 @@ public final class RealisticVillagers extends JavaPlugin {
     private OtherListeners otherListeners;
     private PlayerListeners playerListeners;
     private VillagerListeners villagerListeners;
+    private MarriageListener marriageListener;
 
     private VillagerTracker tracker;
     private @Setter Shape ring;
@@ -272,7 +273,8 @@ public final class RealisticVillagers extends JavaPlugin {
                 (inventoryListeners = new InventoryListeners(this)),
                 (otherListeners = new OtherListeners(this)),
                 (playerListeners = new PlayerListeners(this)),
-                (villagerListeners = new VillagerListeners(this)));
+                (villagerListeners = new VillagerListeners(this))),
+                (marriageListener = new MarriageListener(this)));
 
         // Used in previous versions, not needed any more.
         FileUtils.deleteQuietly(new File(getDataFolder(), "villagers.yml"));

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -26,6 +26,7 @@ import me.matsubara.realisticvillagers.manager.gift.GiftManager;
 import me.matsubara.realisticvillagers.manager.revive.ReviveManager;
 import me.matsubara.realisticvillagers.nms.INMSConverter;
 import me.matsubara.realisticvillagers.tracker.VillagerTracker;
+import me.matsubara.realisticvillagers.entity.PlayerProcreationTracker;
 import me.matsubara.realisticvillagers.util.*;
 import me.matsubara.realisticvillagers.util.customblockdata.CustomBlockData;
 import net.wesjd.anvilgui.AnvilGUI;
@@ -100,6 +101,7 @@ public final class RealisticVillagers extends JavaPlugin {
     private VillagerListeners villagerListeners;
     private MarriageListener marriageListener;
 
+    private PlayerProcreationTracker playerProcreationTracker;
     private VillagerTracker tracker;
     private @Setter Shape ring;
     private @Setter Shape whistle;

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -273,8 +273,10 @@ public final class RealisticVillagers extends JavaPlugin {
                 (inventoryListeners = new InventoryListeners(this)),
                 (otherListeners = new OtherListeners(this)),
                 (playerListeners = new PlayerListeners(this)),
-                (villagerListeners = new VillagerListeners(this))),
-                (marriageListener = new MarriageListener(this)));
+                (villagerListeners = new VillagerListeners(this)),
+                (marriageListener = new MarriageListener(this))
+        );
+
 
         // Used in previous versions, not needed any more.
         FileUtils.deleteQuietly(new File(getDataFolder(), "villagers.yml"));

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -290,6 +290,7 @@ public final class RealisticVillagers extends JavaPlugin {
         command.setExecutor(main);
         command.setTabCompleter(main);
 
+
         logLoadingTime(false, now);
 
         logger.info("****************************************");
@@ -346,7 +347,7 @@ public final class RealisticVillagers extends JavaPlugin {
     public void updateConfigs() {
         String pluginFolder = getDataFolder().getPath();
         String skinFolder = getSkinFolder();
-
+        this.playerProcreationTracker = new PlayerProcreationTracker();
         Predicate<FileConfiguration> noVersion = temp -> !temp.contains("config-version");
 
         // config.yml
@@ -550,6 +551,8 @@ public final class RealisticVillagers extends JavaPlugin {
             exception.printStackTrace();
         }
     }
+
+    public PlayerProcreationTracker getProcreationTracker() {return playerProcreationTracker;}
 
     public record ConfigChanges(Predicate<FileConfiguration> predicate,
                                 Consumer<FileConfiguration> consumer,

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -801,12 +801,9 @@ public final class RealisticVillagers extends JavaPlugin {
         if (!file.exists()) saveResource(name, false);
     }
     //MarriageMaster
-
-
     private boolean marriedPlayer(@NotNull Player player) {
 
         Plugin marriage = Bukkit.getServer().getPluginManager().getPlugin("MarriageMaster");
-        if (marriage == null) return false;
         return getCompatibilityManager().marriedPlayer(player);
     }
     public boolean isMarried(@NotNull Player player) {
@@ -820,6 +817,7 @@ public final class RealisticVillagers extends JavaPlugin {
             player.getPersistentDataContainer().remove(marriedWith);
             return false;
         }
+        System.out.println("esta casado");
 
         return true;
     }

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -45,6 +45,7 @@ import org.bukkit.inventory.*;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.Metadatable;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionType;
@@ -164,6 +165,7 @@ public final class RealisticVillagers extends JavaPlugin {
         addCompatibility("EliteMobs", EMCompatibility::new);
         addCompatibility("ViaVersion", ViaCompatibility::new);
         addCompatibility("VillagerTradeLimiter", VTLCompatibility::new);
+        addCompatibility("MarriageMaster", MarriageCompatibility::new);
 
         logger.info("Compatibilities loaded!");
         logger.info("");
@@ -760,6 +762,7 @@ public final class RealisticVillagers extends JavaPlugin {
 
         TextureProperty textures = tracker.getTextures(npc.getSex(), "none", npc.getSkinTextureId());
         return textures.getName().equals("error") ? UNKNOWN_HEAD_TEXTURE : PluginUtils.getURLFromTexture(textures.getValue());
+
     }
 
     private @NotNull Set<Color> getColors(@NotNull FileConfiguration config, String path, String effect, String needed) {
@@ -793,11 +796,20 @@ public final class RealisticVillagers extends JavaPlugin {
         File file = new File(getDataFolder(), name);
         if (!file.exists()) saveResource(name, false);
     }
+    //MarriageMaster
 
+
+    private boolean marriedPlayer(@NotNull Player player) {
+
+        Plugin marriage = Bukkit.getServer().getPluginManager().getPlugin("MarriageMaster");
+        if (marriage == null) return false;
+        return getCompatibilityManager().marriedPlayer(player);
+    }
     public boolean isMarried(@NotNull Player player) {
         String partner = player.getPersistentDataContainer().get(marriedWith, PersistentDataType.STRING);
         if (partner == null) return false;
 
+        if (!marriedPlayer(player)) return false;
         IVillagerNPC partnerInfo = tracker.getOffline(UUID.fromString(partner));
         if (partnerInfo == null) {
             player.getPersistentDataContainer().remove(marriedWith);
@@ -854,6 +866,7 @@ public final class RealisticVillagers extends JavaPlugin {
         // Not really a gift, but we use the same system.
         return GiftCategory.appliesToVillager(wantedItems, npc, item, isItemPickup);
     }
+
 
     public @Nullable LivingEntity getUnloadedOffline(@NotNull IVillagerNPC offline) {
         LivingEntity bukkit = offline.bukkit();

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -813,7 +813,7 @@ public final class RealisticVillagers extends JavaPlugin {
         String partner = player.getPersistentDataContainer().get(marriedWith, PersistentDataType.STRING);
         if (partner == null) return false;
 
-        if (marriedPlayer(player)) return false;
+        if (marriedPlayer(player)) return true;
         
         IVillagerNPC partnerInfo = tracker.getOffline(UUID.fromString(partner));
         if (partnerInfo == null) {

--- a/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/RealisticVillagers.java
@@ -813,7 +813,7 @@ public final class RealisticVillagers extends JavaPlugin {
         String partner = player.getPersistentDataContainer().get(marriedWith, PersistentDataType.STRING);
         if (partner == null) return false;
 
-        if (marriedPlayer(player)) return true;
+        if (!marriedPlayer(player)) return false;
         
         IVillagerNPC partnerInfo = tracker.getOffline(UUID.fromString(partner));
         if (partnerInfo == null) {

--- a/core/src/main/java/me/matsubara/realisticvillagers/command/MainCommand.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/command/MainCommand.java
@@ -313,7 +313,7 @@ public class MainCommand implements CommandExecutor, TabCompleter {
         plugin.getMessages().send(sender, notFound);
         return null;
     }
-    private CompatibilityManager compatibilityManager;
+
     private void handleForceDivorce(CommandSender sender, @NotNull String[] args) {
         Messages messages = plugin.getMessages();
         VillagerTracker tracker = plugin.getTracker();

--- a/core/src/main/java/me/matsubara/realisticvillagers/command/MainCommand.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/command/MainCommand.java
@@ -2,6 +2,7 @@ package me.matsubara.realisticvillagers.command;
 
 import com.github.retrooper.packetevents.protocol.player.TextureProperty;
 import me.matsubara.realisticvillagers.RealisticVillagers;
+import me.matsubara.realisticvillagers.compatibility.CompatibilityManager;
 import me.matsubara.realisticvillagers.entity.IVillagerNPC;
 import me.matsubara.realisticvillagers.files.Config;
 import me.matsubara.realisticvillagers.files.Messages;
@@ -29,6 +30,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +42,8 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static org.bukkit.Bukkit.getServer;
 
 public class MainCommand implements CommandExecutor, TabCompleter {
 
@@ -309,7 +313,7 @@ public class MainCommand implements CommandExecutor, TabCompleter {
         plugin.getMessages().send(sender, notFound);
         return null;
     }
-
+    private CompatibilityManager compatibilityManager;
     private void handleForceDivorce(CommandSender sender, @NotNull String[] args) {
         Messages messages = plugin.getMessages();
         VillagerTracker tracker = plugin.getTracker();
@@ -342,6 +346,7 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                     string -> string.replace("%player-name%", Objects.requireNonNullElse(offline.getName(), "???")));
             return;
         }
+
 
         for (IVillagerNPC offlineVillager : tracker.getOfflineVillagers()) {
             if (!offlineVillager.getUniqueId().equals(partnerUUID)) continue;

--- a/core/src/main/java/me/matsubara/realisticvillagers/compatibility/CompatibilityManager.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/compatibility/CompatibilityManager.java
@@ -29,4 +29,7 @@ public class CompatibilityManager {
     public boolean shouldCancelMetadata(Player player) {
         return compatibilities.get("ViaVersion") instanceof ViaCompatibility via && via.cancelMetadata(player);
     }
+    public boolean marriedPlayer(Player player) {
+        return compatibilities.get("MarriageMaster") instanceof MarriageCompatibility marriage && marriage.marriedPlayer(player);
+    }
 }

--- a/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
@@ -1,0 +1,32 @@
+package me.matsubara.realisticvillagers.compatibility;
+
+import at.pcgamingfreaks.MarriageMaster.API.MarriageMasterPlugin;
+
+import at.pcgamingfreaks.MarriageMaster.API.MarriageManager;
+import at.pcgamingfreaks.MarriageMaster.API.MarriagePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Villager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+
+public class MarriageCompatibility implements Compatibility {
+
+    public MarriageMasterPlugin getMarriageMaster() {
+        Plugin bukkitPlugin = Bukkit.getPluginManager().getPlugin("MarriageMaster");
+        return (MarriageMasterPlugin) bukkitPlugin;
+
+    }
+    public boolean marriedPlayer(@NotNull Player player) {
+
+        UUID playerUUID = player.getUniqueId();
+        MarriagePlayer data = getMarriageMaster().getPlayerData(playerUUID);
+        return data.isMarried();
+    }
+    @Override
+    public boolean shouldTrack(Villager villager) {return true;}
+}
+

--- a/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
@@ -10,21 +10,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
-
-
-
 public class MarriageCompatibility implements Compatibility {
-
-
     public MarriageMasterPlugin getMarriageMaster() {
         Plugin bukkitPlugin = Bukkit.getPluginManager().getPlugin("MarriageMaster");
         return (MarriageMasterPlugin) bukkitPlugin;
 
     }
     public boolean marriedPlayer(@NotNull Player player) {
-
         UUID playerUUID = player.getUniqueId();
         MarriagePlayer data = getMarriageMaster().getPlayerData(playerUUID);
+        if (data.isMarried() == true) {System.out.println("isMarried: " + data.isMarried());}
         return data.isMarried();
     }
     @Override

--- a/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
@@ -25,7 +25,6 @@ public class MarriageCompatibility implements Compatibility {
 
         UUID playerUUID = player.getUniqueId();
         MarriagePlayer data = getMarriageMaster().getPlayerData(playerUUID);
-        System.out.println("marriedplayer");
         return data.isMarried();
     }
     @Override

--- a/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
@@ -13,13 +13,17 @@ import java.util.UUID;
 public class MarriageCompatibility implements Compatibility {
     public MarriageMasterPlugin getMarriageMaster() {
         Plugin bukkitPlugin = Bukkit.getPluginManager().getPlugin("MarriageMaster");
+        if (bukkitPlugin == null || !(bukkitPlugin instanceof MarriageMasterPlugin)) {
+            return null;
+        }
         return (MarriageMasterPlugin) bukkitPlugin;
 
     }
     public boolean marriedPlayer(@NotNull Player player) {
+        MarriageMasterPlugin marriageMaster = getMarriageMaster();
+        if (marriageMaster == null) {return false;}
         UUID playerUUID = player.getUniqueId();
         MarriagePlayer data = getMarriageMaster().getPlayerData(playerUUID);
-        if (data.isMarried() == true) {System.out.println("isMarried: " + data.isMarried());}
         return data.isMarried();
     }
     @Override

--- a/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/compatibility/MarriageCompatibility.java
@@ -1,8 +1,6 @@
 package me.matsubara.realisticvillagers.compatibility;
 
 import at.pcgamingfreaks.MarriageMaster.API.MarriageMasterPlugin;
-
-import at.pcgamingfreaks.MarriageMaster.API.MarriageManager;
 import at.pcgamingfreaks.MarriageMaster.API.MarriagePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -13,7 +11,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 
+
+
 public class MarriageCompatibility implements Compatibility {
+
 
     public MarriageMasterPlugin getMarriageMaster() {
         Plugin bukkitPlugin = Bukkit.getPluginManager().getPlugin("MarriageMaster");
@@ -24,6 +25,7 @@ public class MarriageCompatibility implements Compatibility {
 
         UUID playerUUID = player.getUniqueId();
         MarriagePlayer data = getMarriageMaster().getPlayerData(playerUUID);
+        System.out.println("marriedplayer");
         return data.isMarried();
     }
     @Override

--- a/core/src/main/java/me/matsubara/realisticvillagers/entity/PlayerProcreationTracker.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/entity/PlayerProcreationTracker.java
@@ -1,0 +1,27 @@
+package me.matsubara.realisticvillagers.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerProcreationTracker {
+
+    // Stores player procreation times (player1 -> (player2 -> timestamp))
+    private final Map<UUID, Map<UUID, Long>> procreationTimes = new HashMap<>();
+
+    public void setLastProcreation(UUID player1, UUID player2) {
+        long currentTime = System.currentTimeMillis();
+
+
+        procreationTimes.putIfAbsent(player1, new HashMap<>());
+        procreationTimes.putIfAbsent(player2, new HashMap<>());
+
+        procreationTimes.get(player1).put(player2, currentTime);
+        procreationTimes.get(player2).put(player1, currentTime);
+    }
+
+
+    public long getLastProcreation(UUID player1, UUID player2) {
+        return procreationTimes.getOrDefault(player1, new HashMap<>()).getOrDefault(player2, 0L);
+    }
+}

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -35,8 +35,8 @@ public class MarriageListener implements Listener {
 
 
 
-        MarriagePlayer marriedplayer1 = event.getPartner1();
-        MarriagePlayer marriedplayer2 = event.getPartner2();
+        MarriagePlayer marriedplayer1 = event.getPlayer1();
+        MarriagePlayer marriedplayer2 = event.getPlayer2();
 
         Player player1 = marriedplayer1.getPlayerOnline();
         Player player2 = marriedplayer2.getPlayerOnline();

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -20,7 +20,6 @@ import org.bukkit.persistence.PersistentDataType;
 import me.matsubara.realisticvillagers.entity.PlayerProcreationTracker;
 import java.util.UUID;
 
-import static com.sun.org.apache.xml.internal.serializer.utils.Utils.messages;
 
 
 public class MarriageListener implements Listener {

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -1,7 +1,8 @@
 package me.matsubara.realisticvillagers.listener;
-
-import at.pcgamingfreaks.MarriageMaster.API.MarriageMasterPlugin;
-import at.pcgamingfreaks.MarriageMaster.API.MarriagePlayer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriageMasterPlugin;
+import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriagePlayer;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.MarriedEvent;
 import me.matsubara.realisticvillagers.RealisticVillagers;
 import me.matsubara.realisticvillagers.entity.IVillagerNPC;
@@ -29,20 +30,20 @@ public class MarriageListener implements Listener {
 
     @EventHandler
     private void ForceDivorcewhenmarried(MarriedEvent event) {
-
+        MarriageMasterPlugin marriageMasterPlugin = (MarriageMasterPlugin) Bukkit.getPluginManager().getPlugin("MarriageMaster");
         Messages messages = plugin.getMessages();
         VillagerTracker tracker = plugin.getTracker();
         INMSConverter converter = plugin.getConverter();
 
 
-        MarriagePlayer marriagePlayer1 =  event.getMarriageData().getPartner1(); // Get MarriagePlayer
-        MarriagePlayer marriagePlayer2 =  event.getMarriageData().getPartner2();
+        // Obtener los UUIDs de los jugadores
+        UUID playerUUID1 = event.getMarriageData().getPartner1().getUUID();
+        UUID playerUUID2 = event.getMarriageData().getPartner2().getUUID();
 
-        Player player1 = (Player) marriagePlayer1.getPlayer(); // Convert to Bukkit Player
-        Player player2 = (Player) marriagePlayer2.getPlayer();
 
-        UUID playerUUID1 = player1.getUniqueId(); // Get UUID
-        UUID playerUUID2 = player2.getUniqueId();
+        // Convertir MarriagePlayer a Player de Bukkit
+        Player player1 = Bukkit.getPlayer(playerUUID1);
+        Player player2 = Bukkit.getPlayer(playerUUID2);
 
 
 

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -33,18 +33,11 @@ public class MarriageListener implements Listener {
         VillagerTracker tracker = plugin.getTracker();
         INMSConverter converter = plugin.getConverter();
 
-
-
         MarriagePlayer marriedplayer1 = event.getPlayer1();
         MarriagePlayer marriedplayer2 = event.getPlayer2();
 
         Player player1 = marriedplayer1.getPlayerOnline();
         Player player2 = marriedplayer2.getPlayerOnline();
-
-
-
-
-
 
         String uuidString1 = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
         if (uuidString1 != null) partnerUUID1 = UUID.fromString(uuidString1);
@@ -53,8 +46,6 @@ public class MarriageListener implements Listener {
         String uuidString2 = player2.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
         if (uuidString2 != null) partnerUUID2 = UUID.fromString(uuidString2);;
         player2.getPersistentDataContainer().remove(plugin.getMarriedWith());
-
-
 
         for (IVillagerNPC offlineVillager : tracker.getOfflineVillagers()) {
             if (!offlineVillager.getUniqueId().equals(partnerUUID1)) continue;
@@ -65,7 +56,6 @@ public class MarriageListener implements Listener {
                 if (bukkit == null) continue;
             }
 
-            // In this case, we don't need to ignore invalid villagers.
             IVillagerNPC npc = converter.getNPC(bukkit).orElse(null);
             if (npc == null) continue;
 
@@ -81,15 +71,11 @@ public class MarriageListener implements Listener {
                 if (bukkit == null) continue;
             }
 
-            // In this case, we don't need to ignore invalid villagers.
             IVillagerNPC npc = converter.getNPC(bukkit).orElse(null);
             if (npc == null) continue;
 
             npc.divorceAndDropRing(player1);
             break;
         }
-
-        // At this point, either the player or the villager (or both) should be divorced.
-
     }
 }

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -1,12 +1,11 @@
 package me.matsubara.realisticvillagers.listener;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.KissEvent;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriagePlayer;
+import me.matsubara.realisticvillagers.entity.PlayerProcreationTracker;
 import me.matsubara.realisticvillagers.files.Config;
 import me.matsubara.realisticvillagers.task.BabyTaskPlayer;
 import me.matsubara.realisticvillagers.util.PluginUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriageMasterPlugin;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.MarriedEvent;
 import me.matsubara.realisticvillagers.RealisticVillagers;
 import me.matsubara.realisticvillagers.entity.IVillagerNPC;
@@ -17,9 +16,10 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.persistence.PersistentDataType;
-import me.matsubara.realisticvillagers.entity.PlayerProcreationTracker;
-import java.util.UUID;
 
+import java.io.File;
+import java.util.Objects;
+import java.util.UUID;
 
 
 public class MarriageListener implements Listener {
@@ -28,12 +28,11 @@ public class MarriageListener implements Listener {
     public MarriageListener(RealisticVillagers plugin) {
         this.plugin = plugin;
     }
-    private UUID partnerUUID1;
-    private UUID partnerUUID2;
-
 
     @EventHandler
     private void ForceDivorcewhenmarried(MarriedEvent event) {
+        UUID partnerUUID1 = null;
+        UUID partnerUUID2 = null;
         Messages messages = plugin.getMessages();
         VillagerTracker tracker = plugin.getTracker();
         INMSConverter converter = plugin.getConverter();
@@ -44,13 +43,34 @@ public class MarriageListener implements Listener {
         Player player1 = marriedplayer1.getPlayerOnline();
         Player player2 = marriedplayer2.getPlayerOnline();
 
-        String uuidString1 = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
-        if (uuidString1 != null) partnerUUID1 = UUID.fromString(uuidString1);
-        player1.getPersistentDataContainer().remove(plugin.getMarriedWith());
+        Player offlinePlayer1 = marriedplayer1.getPlayer().getPlayer();
+        Player offlinePlayer2 = marriedplayer2.getPlayer().getPlayer();
 
-        String uuidString2 = player2.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
-        if (uuidString2 != null) partnerUUID2 = UUID.fromString(uuidString2);;
-        player2.getPersistentDataContainer().remove(plugin.getMarriedWith());
+        if (player1 != null) {
+            String uuidString1 = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
+            if (uuidString1 != null) {
+                partnerUUID1 = UUID.fromString(uuidString1);
+                player1.getPersistentDataContainer().remove(plugin.getMarriedWith());
+            }
+        } else if (offlinePlayer1 != null) {
+            File playerFile1 = tracker.getPlayerNBTFile(offlinePlayer1.getUniqueId());
+            if (playerFile1 != null && (partnerUUID1 = converter.getPartnerUUIDFromPlayerNBT(playerFile1)) != null) {
+                converter.removePartnerFromPlayerNBT(playerFile1);
+            }
+        }
+
+        if (player2 != null) {
+            String uuidString2 = player2.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
+            if (uuidString2 != null) {
+                partnerUUID2 = UUID.fromString(uuidString2);
+                player2.getPersistentDataContainer().remove(plugin.getMarriedWith());
+            }
+        } else if (offlinePlayer2 != null) {
+            File playerFile2 = tracker.getPlayerNBTFile(offlinePlayer2.getUniqueId());
+            if (playerFile2 != null && (partnerUUID2 = converter.getPartnerUUIDFromPlayerNBT(playerFile2)) != null) {
+                converter.removePartnerFromPlayerNBT(playerFile2);
+            }
+        }
 
         for (IVillagerNPC offlineVillager : tracker.getOfflineVillagers()) {
             if (!offlineVillager.getUniqueId().equals(partnerUUID1)) continue;
@@ -65,6 +85,10 @@ public class MarriageListener implements Listener {
             if (npc == null) continue;
 
             npc.divorceAndDropRing(player1);
+            messages.send(
+                    player1,
+                    Messages.Message.DIVORCED,
+                    string -> string.replace("%player-name%", Objects.requireNonNullElse(offlinePlayer1.getName(), "???")));
             break;
         }
         for (IVillagerNPC offlineVillager : tracker.getOfflineVillagers()) {
@@ -79,13 +103,18 @@ public class MarriageListener implements Listener {
             IVillagerNPC npc = converter.getNPC(bukkit).orElse(null);
             if (npc == null) continue;
 
-            npc.divorceAndDropRing(player1);
+            npc.divorceAndDropRing(player2);
+            messages.send(
+                    player2,
+                    Messages.Message.DIVORCED,
+                    string -> string.replace("%player-name%", Objects.requireNonNullElse(offlinePlayer1.getName(), "???")));
             break;
         }
     }
 
     @EventHandler
     private void KidWhenKissing(KissEvent event) {
+        Messages messages = plugin.getMessages();
         MarriagePlayer kisser = event.getPlayer();
         MarriagePlayer partner = event.getPlayer().getPartner();
 
@@ -95,10 +124,20 @@ public class MarriageListener implements Listener {
         UUID player1UUID = kisserplayer.getUniqueId();
         UUID player2UUID = partnerplayer.getUniqueId();
 
+        PlayerProcreationTracker procreationTracker = plugin.getProcreationTracker();
+        long playerlastProcreation = procreationTracker.getLastProcreation(player1UUID, player2UUID);
+        long playerelapsedTime = System.currentTimeMillis() - playerlastProcreation;
 
+        int playerprocreationCooldown = Config.PROCREATION_COOLDOWN.asInt();
+
+        if (playerelapsedTime <= playerprocreationCooldown) {
+            String next = PluginUtils.getTimeString(playerprocreationCooldown - playerelapsedTime);
+            messages.send(kisserplayer, Messages.Message.PROCREATE_FAIL_HAS_BABY);
+            messages.send(kisserplayer, Messages.Message.PROCREATE_COOLDOWN, string -> string.replace("%time%", next));
+            return;
+        }
 
         new BabyTaskPlayer(plugin, partnerplayer, kisserplayer).runTaskTimer(plugin, 0L, 20L);
-
 
     }
 }

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -3,8 +3,6 @@ package me.matsubara.realisticvillagers.listener;
 import at.pcgamingfreaks.MarriageMaster.API.MarriageMasterPlugin;
 import at.pcgamingfreaks.MarriageMaster.API.MarriagePlayer;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.MarriedEvent;
-import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import me.matsubara.realisticvillagers.RealisticVillagers;
 import me.matsubara.realisticvillagers.entity.IVillagerNPC;
 import me.matsubara.realisticvillagers.files.Messages;
@@ -24,24 +22,29 @@ public class MarriageListener implements Listener {
 
     public MarriageListener(RealisticVillagers plugin) {
         this.plugin = plugin;
-        PacketEvents.getAPI().getEventManager().registerListener(this);
     }
+    private UUID partnerUUID1;
+    private UUID partnerUUID2;
+
 
     @EventHandler
     private void ForceDivorcewhenmarried(MarriedEvent event) {
+
         Messages messages = plugin.getMessages();
         VillagerTracker tracker = plugin.getTracker();
         INMSConverter converter = plugin.getConverter();
 
 
-        MarriagePlayer marriagePlayer1 = event.getPlayer1(); // Get MarriagePlayer
-        MarriagePlayer marriagePlayer2 = event.getPlayer2();
+        MarriagePlayer marriagePlayer1 =  event.getMarriageData().getPartner1(); // Get MarriagePlayer
+        MarriagePlayer marriagePlayer2 =  event.getMarriageData().getPartner2();
 
-        UUID playerUUID1 = marriagePlayer1.getUniqueId(); // Get UUID
-        UUID playerUUID2 = marriagePlayer2.getUniqueId();
+        Player player1 = (Player) marriagePlayer1.getPlayer(); // Convert to Bukkit Player
+        Player player2 = (Player) marriagePlayer2.getPlayer();
 
-        Player player1 = Bukkit.getPlayer(playerUUID1); // Convert to Bukkit Player
-        Player player2 = Bukkit.getPlayer(playerUUID2);
+        UUID playerUUID1 = player1.getUniqueId(); // Get UUID
+        UUID playerUUID2 = player2.getUniqueId();
+
+
 
 
         String uuidString = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -1,17 +1,15 @@
 package me.matsubara.realisticvillagers.listener;
+import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriagePlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriageMasterPlugin;
-import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriagePlayer;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.MarriedEvent;
 import me.matsubara.realisticvillagers.RealisticVillagers;
 import me.matsubara.realisticvillagers.entity.IVillagerNPC;
 import me.matsubara.realisticvillagers.files.Messages;
 import me.matsubara.realisticvillagers.nms.INMSConverter;
 import me.matsubara.realisticvillagers.tracker.VillagerTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.persistence.PersistentDataType;
@@ -36,24 +34,24 @@ public class MarriageListener implements Listener {
         INMSConverter converter = plugin.getConverter();
 
 
-        // Obtener los UUIDs de los jugadores
-        UUID playerUUID1 = event.getMarriageData().getPartner1().getUUID();
-        UUID playerUUID2 = event.getMarriageData().getPartner2().getUUID();
 
+        MarriagePlayer marriedplayer1 = event.getPartner1();
+        MarriagePlayer marriedplayer2 = event.getPartner2();
 
-        // Convertir MarriagePlayer a Player de Bukkit
-        Player player1 = Bukkit.getPlayer(playerUUID1);
-        Player player2 = Bukkit.getPlayer(playerUUID2);
-
+        Player player1 = marriedplayer1.getPlayerOnline();
+        Player player2 = marriedplayer2.getPlayerOnline();
 
 
 
-        String uuidString = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
-        if (uuidString != null) partnerUUID1 = playerUUID1;
+
+
+
+        String uuidString1 = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
+        if (uuidString1 != null) partnerUUID1 = UUID.fromString(uuidString1);
         player1.getPersistentDataContainer().remove(plugin.getMarriedWith());
 
         String uuidString2 = player2.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
-        if (uuidString2 != null) partnerUUID2 = playerUUID2;
+        if (uuidString2 != null) partnerUUID2 = UUID.fromString(uuidString2);;
         player2.getPersistentDataContainer().remove(plugin.getMarriedWith());
 
 

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -1,5 +1,9 @@
 package me.matsubara.realisticvillagers.listener;
+import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.KissEvent;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriagePlayer;
+import me.matsubara.realisticvillagers.files.Config;
+import me.matsubara.realisticvillagers.task.BabyTaskPlayer;
+import me.matsubara.realisticvillagers.util.PluginUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.MarriageMasterPlugin;
@@ -13,8 +17,11 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.persistence.PersistentDataType;
-
+import me.matsubara.realisticvillagers.entity.PlayerProcreationTracker;
 import java.util.UUID;
+
+import static com.sun.org.apache.xml.internal.serializer.utils.Utils.messages;
+
 
 public class MarriageListener implements Listener {
     private final RealisticVillagers plugin;
@@ -28,7 +35,6 @@ public class MarriageListener implements Listener {
 
     @EventHandler
     private void ForceDivorcewhenmarried(MarriedEvent event) {
-        MarriageMasterPlugin marriageMasterPlugin = (MarriageMasterPlugin) Bukkit.getPluginManager().getPlugin("MarriageMaster");
         Messages messages = plugin.getMessages();
         VillagerTracker tracker = plugin.getTracker();
         INMSConverter converter = plugin.getConverter();
@@ -77,5 +83,23 @@ public class MarriageListener implements Listener {
             npc.divorceAndDropRing(player1);
             break;
         }
+    }
+
+    @EventHandler
+    private void KidWhenKissing(KissEvent event) {
+        MarriagePlayer kisser = event.getPlayer();
+        MarriagePlayer partner = event.getPlayer().getPartner();
+
+        Player kisserplayer = kisser.getPlayerOnline();
+        Player partnerplayer = partner.getPlayerOnline();
+
+        UUID player1UUID = kisserplayer.getUniqueId();
+        UUID player2UUID = partnerplayer.getUniqueId();
+
+
+
+        new BabyTaskPlayer(plugin, partnerplayer, kisserplayer).runTaskTimer(plugin, 0L, 20L);
+
+
     }
 }

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -1,0 +1,88 @@
+package me.matsubara.realisticvillagers.listener;
+
+
+import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.MarriedEvent;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import me.matsubara.realisticvillagers.RealisticVillagers;
+import me.matsubara.realisticvillagers.entity.IVillagerNPC;
+import me.matsubara.realisticvillagers.files.Messages;
+import me.matsubara.realisticvillagers.nms.INMSConverter;
+import me.matsubara.realisticvillagers.tracker.VillagerTracker;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.UUID;
+
+public class MarriageListener implements Listener {
+    private final RealisticVillagers plugin;
+
+    public MarriageListener(RealisticVillagers plugin) {
+        super(PacketListenerPriority.HIGHEST);
+        this.plugin = plugin;
+        PacketEvents.getAPI().getEventManager().registerListener(this);
+    }
+
+    @EventHandler
+    private void ForceDivorcewhenmarried(MarriedEvent event) {
+        Messages messages = plugin.getMessages();
+        VillagerTracker tracker = plugin.getTracker();
+        INMSConverter converter = plugin.getConverter();
+
+
+        Player player1 = event.getPlayer1();
+        Player player2 = event.getPlayer2();
+        UUID partnerUUID1 = null;
+        UUID partnerUUID2 = null;
+
+
+        String uuidString = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
+        if (uuidString != null) partnerUUID1 = event.getPlayer1().getUUID();
+        player1.getPersistentDataContainer().remove(plugin.getMarriedWith());
+
+        String uuidString2 = player2.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
+        if (uuidString2 != null) partnerUUID2 = event.getPlayer2().getUUID();
+        player2.getPersistentDataContainer().remove(plugin.getMarriedWith());
+
+
+
+        for (IVillagerNPC offlineVillager : tracker.getOfflineVillagers()) {
+            if (!offlineVillager.getUniqueId().equals(partnerUUID1)) continue;
+
+            LivingEntity bukkit = offlineVillager.bukkit();
+            if (bukkit == null) {
+                bukkit = plugin.getUnloadedOffline(offlineVillager);
+                if (bukkit == null) continue;
+            }
+
+            // In this case, we don't need to ignore invalid villagers.
+            IVillagerNPC npc = converter.getNPC(bukkit).orElse(null);
+            if (npc == null) continue;
+
+            npc.divorceAndDropRing(player1);
+            break;
+        }
+        for (IVillagerNPC offlineVillager : tracker.getOfflineVillagers()) {
+            if (!offlineVillager.getUniqueId().equals(partnerUUID2)) continue;
+
+            LivingEntity bukkit = offlineVillager.bukkit();
+            if (bukkit == null) {
+                bukkit = plugin.getUnloadedOffline(offlineVillager);
+                if (bukkit == null) continue;
+            }
+
+            // In this case, we don't need to ignore invalid villagers.
+            IVillagerNPC npc = converter.getNPC(bukkit).orElse(null);
+            if (npc == null) continue;
+
+            npc.divorceAndDropRing(player1);
+            break;
+        }
+
+        // At this point, either the player or the villager (or both) should be divorced.
+
+    }
+}

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/MarriageListener.java
@@ -1,6 +1,7 @@
 package me.matsubara.realisticvillagers.listener;
 
-
+import at.pcgamingfreaks.MarriageMaster.API.MarriageMasterPlugin;
+import at.pcgamingfreaks.MarriageMaster.API.MarriagePlayer;
 import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.MarriedEvent;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
@@ -9,6 +10,7 @@ import me.matsubara.realisticvillagers.entity.IVillagerNPC;
 import me.matsubara.realisticvillagers.files.Messages;
 import me.matsubara.realisticvillagers.nms.INMSConverter;
 import me.matsubara.realisticvillagers.tracker.VillagerTracker;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -21,7 +23,6 @@ public class MarriageListener implements Listener {
     private final RealisticVillagers plugin;
 
     public MarriageListener(RealisticVillagers plugin) {
-        super(PacketListenerPriority.HIGHEST);
         this.plugin = plugin;
         PacketEvents.getAPI().getEventManager().registerListener(this);
     }
@@ -33,18 +34,22 @@ public class MarriageListener implements Listener {
         INMSConverter converter = plugin.getConverter();
 
 
-        Player player1 = event.getPlayer1();
-        Player player2 = event.getPlayer2();
-        UUID partnerUUID1 = null;
-        UUID partnerUUID2 = null;
+        MarriagePlayer marriagePlayer1 = event.getPlayer1(); // Get MarriagePlayer
+        MarriagePlayer marriagePlayer2 = event.getPlayer2();
+
+        UUID playerUUID1 = marriagePlayer1.getUniqueId(); // Get UUID
+        UUID playerUUID2 = marriagePlayer2.getUniqueId();
+
+        Player player1 = Bukkit.getPlayer(playerUUID1); // Convert to Bukkit Player
+        Player player2 = Bukkit.getPlayer(playerUUID2);
 
 
         String uuidString = player1.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
-        if (uuidString != null) partnerUUID1 = event.getPlayer1().getUUID();
+        if (uuidString != null) partnerUUID1 = playerUUID1;
         player1.getPersistentDataContainer().remove(plugin.getMarriedWith());
 
         String uuidString2 = player2.getPersistentDataContainer().get(plugin.getMarriedWith(), PersistentDataType.STRING);
-        if (uuidString2 != null) partnerUUID2 = event.getPlayer2().getUUID();
+        if (uuidString2 != null) partnerUUID2 = playerUUID2;
         player2.getPersistentDataContainer().remove(plugin.getMarriedWith());
 
 

--- a/core/src/main/java/me/matsubara/realisticvillagers/listener/PlayerListeners.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/listener/PlayerListeners.java
@@ -127,6 +127,7 @@ public final class PlayerListeners implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
+
         handleWhistle(event);
         handleBabySpawn(event);
 

--- a/core/src/main/java/me/matsubara/realisticvillagers/manager/ExpectingManager.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/manager/ExpectingManager.java
@@ -11,6 +11,8 @@ import me.matsubara.realisticvillagers.gui.InteractGUI;
 import me.matsubara.realisticvillagers.manager.gift.GiftCategory;
 import me.matsubara.realisticvillagers.util.ItemStackUtils;
 import me.matsubara.realisticvillagers.util.PluginUtils;
+import at.pcgamingfreaks.MarriageMaster.Bukkit.API.Events.DivorcedEvent;
+import at.pcgamingfreaks.MarriageMaster.API.MarriagePlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.EntityEffect;
 import org.bukkit.NamespacedKey;
@@ -60,6 +62,7 @@ public final class ExpectingManager implements Listener {
         if (!(event.getEntity() instanceof Villager villager)) return;
         villagerExpectingCache.entrySet().removeIf(next -> next.getValue().bukkit().equals(villager));
     }
+
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onVillagerFish(@NotNull VillagerFishEvent event) {

--- a/core/src/main/java/me/matsubara/realisticvillagers/task/BabyTaskPlayer.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/task/BabyTaskPlayer.java
@@ -1,14 +1,12 @@
 package me.matsubara.realisticvillagers.task;
 
 import me.matsubara.realisticvillagers.RealisticVillagers;
-import me.matsubara.realisticvillagers.entity.IVillagerNPC;
 import me.matsubara.realisticvillagers.files.Config;
 import net.wesjd.anvilgui.AnvilGUI;
 import org.apache.commons.lang3.RandomUtils;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
@@ -60,9 +58,12 @@ public class BabyTaskPlayer extends BukkitRunnable {
 
                     long procreation = System.currentTimeMillis();
                     player.getInventory().addItem(plugin.createBaby(isBoy, result, procreation, partner.getUniqueId()));
+                    plugin.getProcreationTracker().setLastProcreation(player.getUniqueId(), partner.getUniqueId());
 
                     success = true;
                     return RealisticVillagers.CLOSE_RESPONSE;
+
+
                 })
                 .onClose(opener -> {
                     if (success) return;

--- a/core/src/main/java/me/matsubara/realisticvillagers/task/BabyTaskPlayer.java
+++ b/core/src/main/java/me/matsubara/realisticvillagers/task/BabyTaskPlayer.java
@@ -1,0 +1,75 @@
+package me.matsubara.realisticvillagers.task;
+
+import me.matsubara.realisticvillagers.RealisticVillagers;
+import me.matsubara.realisticvillagers.entity.IVillagerNPC;
+import me.matsubara.realisticvillagers.files.Config;
+import net.wesjd.anvilgui.AnvilGUI;
+import org.apache.commons.lang3.RandomUtils;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+
+public class BabyTaskPlayer extends BukkitRunnable {
+
+    private final RealisticVillagers plugin;
+    private final Player partner;
+    private final Player player;
+    private final boolean isBoy;
+
+    private int count = 0;
+    private boolean success = false;
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public BabyTaskPlayer(@NotNull RealisticVillagers plugin, Player partner, Player player) {
+        this.plugin = plugin;
+        // No need to check if it's invalid, the main GUI can only be opened by valid villagers.
+        this.partner = partner;
+        this.player = player;
+        this.isBoy = RandomUtils.nextBoolean();
+    }
+
+    @Override
+    public void run() {
+        if (++count == 10) {
+            openInventory(Config.BABY_TEXT.asStringTranslated());
+            cancel();
+            return;
+        }
+
+
+        player.spawnParticle(Particle.HEART, partner.getEyeLocation(), 3, 0.1d, 0.1d, 0.1d);
+    }
+
+    private void openInventory(String text) {
+        new AnvilGUI.Builder()
+                .title(Config.BABY_TITLE.asStringTranslated().replace("%sex%", isBoy ? Config.BOY.asString() : Config.GIRL.asString()))
+                .text(text)
+                .itemLeft(new ItemStack(Material.PAPER))
+                .onClick((slot, snapshot) -> {
+                    if (slot != AnvilGUI.Slot.OUTPUT) return Collections.emptyList();
+
+                    String result = snapshot.getText();
+
+                    if (result.length() < 3) return RealisticVillagers.CLOSE_RESPONSE;
+
+                    long procreation = System.currentTimeMillis();
+                    player.getInventory().addItem(plugin.createBaby(isBoy, result, procreation, partner.getUniqueId()));
+
+                    success = true;
+                    return RealisticVillagers.CLOSE_RESPONSE;
+                })
+                .onClose(opener -> {
+                    if (success) return;
+                    plugin.getServer().getScheduler().runTask(plugin, () -> openInventory(Config.BABY_INVALID_NAME.asStringTranslated()));
+                })
+                .plugin(plugin)
+                .open(player)
+                .getInventory();
+    }
+}

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -14,6 +14,7 @@ softdepend:
   - ViaBackwards
   - ViaRewind
   - Geyser-Spigot
+  - MarriageMaster
 
 commands:
   realisticvillagers:

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -61,7 +61,7 @@
         <!-- core -->
         <dependency>
             <groupId>me.matsubara</groupId>
-            <artifactId>realisticvillagers-core</artifactId>
+                        <artifactId>realisticvillagers-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <!-- v1_18 -->
@@ -104,12 +104,6 @@
         <dependency>
             <groupId>me.matsubara</groupId>
             <artifactId>realisticvillagers-v1_21</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <!-- v1_21_4 -->
-        <dependency>
-            <groupId>me.matsubara</groupId>
-            <artifactId>realisticvillagers-v1_21_4</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <module>v1_20_4</module>
         <module>v1_20_6</module>
         <module>v1_21</module>
-        <module>v1_21_4</module>
         <module>core</module>
         <module>dist</module>
     </modules>

--- a/v1_21/src/main/java/me/matsubara/realisticvillagers/entity/v1_21/villager/VillagerNPC.java
+++ b/v1_21/src/main/java/me/matsubara/realisticvillagers/entity/v1_21/villager/VillagerNPC.java
@@ -671,7 +671,7 @@ public class VillagerNPC extends Villager implements IVillagerNPC, CrossbowAttac
         stopExchangeables();
         stopInteracting();
         stopStayingInPlace();
-        stopExpecting();
+
     }
 
     @Override


### PR DESCRIPTION

I have added compatibility with the [MarriageMsterPlugin](https://github.com/GeorgH93/MarriageMaster/tree/4525e823a633e6477c18f9dfe176f26d397ed31a)

## Features:

- When player marry with other player the villager will autodivorce.
- When the player is married he cannot marry a villager
- Married players can have children by using the /kiss command or right clicking their partner while shifting.
- Players when they have the child will have the cooldown to have another child like the villagers.

## Problems
- When i remove marriage master i have this console error but the plugin still works perfectly:   
> `[RealisticVillagers] Failed to register events for class me.matsubara.realisticvillagers.listener.MarriageListener because 
    at/pcgamingfreaks/MarriageMaster/Bukkit/API/Events/MarriedEvent does not exist.` 
- This compatibility cannot be turned off from the config

Sorry i am new :(

That's it, you can copy my code if you want and add it directly. I thank you very much for this plugin so nice and so full as well as a very clean and understandable code. :)